### PR TITLE
New Release: 2.11.0 - Rocky 9 support

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: usegalaxy_eu
 name: handy
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.10.0
+version: 2.11.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/os_setup/README.md
+++ b/roles/os_setup/README.md
@@ -22,7 +22,7 @@ Tasks
 * kernel_5: install kernel-{lt, ml} package from ELRepo repo
 * pam_limits: prevent user from creating files larger than n TB
 * grub: add a grub option needed to visualize VM's logs into the OpenStack dashboard
-* cgroups: install and enable cgroups
+* cgroups: install and enable cgroups ⚠️ cgroupsv2 are default in Rocky 9 so this is not used
 * journald: configure journald
 * install_software: install software from a list of groups
 * ansible_root_cron: install cron tasks as root


### PR DESCRIPTION
- user/group remapping without hardcoded names
- disabled cgroups installation for rocky 9, because cgroupsv2 are default now
- use package `apptainer` instead of singularity for Rocky 9