### PR TITLE
Fixed font installation on Rocky 9

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: usegalaxy_eu
 name: handy
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.11.0
+version: 2.11.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/os_setup/defaults/main.yml
+++ b/roles/os_setup/defaults/main.yml
@@ -59,7 +59,7 @@ software_packages:
     - iotop
     - iftop
   apps:
-    - "{{ apptainer if ansible_facts['distribution_major_version'] == '9' else singularity }}"
+    - apptainer
   configuration:
     - ansible
   cgroups:
@@ -79,7 +79,7 @@ software_packages:
     - vim
     - nano
   fonts:
-    - dejavu-fonts-common
+    - dejavu-fonts-all
     - dejavu-sans-fonts
     - dejavu-sans-mono-fonts
     - dejavu-serif-fonts
@@ -93,7 +93,7 @@ software_packages:
     - perl-Digest-MD5
     - perl-Digest-SHA
     - urw-fonts
-    - xorg-x11-font-utils
+    - mkfontscale
   services:
     - {'package_name': 'at', 'daemon_name': 'atd'}
     - {'package_name': 'atop', 'daemon_name': 'atop'}

--- a/roles/os_setup/tasks/install_software.yml
+++ b/roles/os_setup/tasks/install_software.yml
@@ -56,11 +56,25 @@
   when: "'editors' in software_groups_to_install"
 
 - name: Install fonts software groups
-  ansible.builtin.package:
-    state: latest
-    name: "{{ item }}"
-  loop:
-    - "{{ software_packages.fonts }}"
+  block:
+
+    - name: Install packages EL 9
+      ansible.builtin.dnf:
+        state: latest
+        enablerepo: devel
+        name: "{{ item }}"
+      loop:
+        - "{{ software_packages.fonts }}"
+      when: (ansible_distribution_major_version == '9' and ansible_os_family == "RedHat")
+    
+    - name: Install packages for other releases
+      ansible.builtin.package:
+        state: latest
+        name: "{{ item }}"
+      loop:
+        - "{{ software_packages.fonts }}"
+      when: (not ansible_distribution_major_version == '9')
+
   when: "'fonts' in software_groups_to_install"
 
 - name: Install services software groups

--- a/roles/os_setup/tasks/install_software.yml
+++ b/roles/os_setup/tasks/install_software.yml
@@ -66,7 +66,7 @@
       loop:
         - "{{ software_packages.fonts }}"
       when: (ansible_distribution_major_version == '9' and ansible_os_family == "RedHat")
-    
+
     - name: Install packages for other releases
       ansible.builtin.package:
         state: latest


### PR DESCRIPTION
Now using `mkfontscale` because the big `xorg-x11-font-utils` package was now deaggregated. It should do the job.
Rock 9 needs the devel repo enabled for `dejavu-fonts-all` which should replace `dejavu-fonts-common`