### PR TITLE
Install findutils in remap_user.yml from os_setup role

### DIFF
--- a/roles/os_setup/tasks/remap_user.yml
+++ b/roles/os_setup/tasks/remap_user.yml
@@ -2,6 +2,12 @@
 # RHEL uses GID 999 and UID 999, both of which need to be
 # mapped to the galaxy user and group.
 
+- name: Ensure findutils is installed
+  become: true
+  ansible.builtin.package:
+    name: findutils
+    state: installed
+
 - name: Get all groups
   getent:
     database: group


### PR DESCRIPTION
`find` is required to run [some](https://github.com/kysrpex/usegalaxy-eu-ansible-collection-handy/blob/81234fdd6f7f6ebc6afc135a82d6224f34d259d2/roles/os_setup/tasks/remap_user.yml#L42-L48) [tasks](https://github.com/kysrpex/usegalaxy-eu-ansible-collection-handy/blob/81234fdd6f7f6ebc6afc135a82d6224f34d259d2/roles/os_setup/tasks/remap_user.yml#L73-L79) in [remap_user.yml](https://github.com/kysrpex/usegalaxy-eu-ansible-collection-handy/blob/81234fdd6f7f6ebc6afc135a82d6224f34d259d2/roles/os_setup/tasks/remap_user.yml), so install `findutils` to satisfy the dependencies.

With this PR, I can remove [this task](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/ee6f97df8b6a8870e8bf8f7ac24980cf4392d533/htcondor.yml#L217-L221) from the [HTCondor playbook](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/ee6f97df8b6a8870e8bf8f7ac24980cf4392d533/htcondor.yml). It became obvious that the role requires `find` because `findutils` does not come installed in the systemd-nspawn container image.