### PR TITLE
Bump collection version number to 3.1.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: usegalaxy_eu
 name: handy
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.0.2
+version: 3.1.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
The only changes since the last release are those introduced by https://github.com/usegalaxy-eu/ansible-collection-handy/pull/18.

According to https://semver.org/spec/v2.0.0.html:

- "6. Patch version Z (x.y.Z | x > 0) MUST be incremented if only backward compatible bug fixes are introduced. A bug fix is defined as an internal change that fixes incorrect behavior."
- "7. Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backward compatible functionality is introduced to the public API. [...] It MAY be incremented if substantial new functionality or improvements are introduced within the private code."
- "8. Major version X (X.y.z | X > 0) MUST be incremented if any backward incompatible changes are introduced to the public API."

PR #18 qualifies both as "substantial new functionality or improvements are introduced within the private code" and "backward compatible bug fixes", thus I am increasing the minor version number.