### PR TITLE
Use Bash for all shell tasks

### DIFF
--- a/roles/os_setup/tasks/remap_user.yml
+++ b/roles/os_setup/tasks/remap_user.yml
@@ -32,6 +32,7 @@
   block:
     - name: Compute user mapping using script.
       ansible.builtin.shell:
+        executable: /bin/bash
         chdir: "{{ role_path }}/files"
         cmd: |
           set -o pipefail;
@@ -58,6 +59,7 @@
   block:
     - name: Compute group mapping using script.
       ansible.builtin.shell:
+        executable: /bin/bash
         chdir: "{{ role_path }}/files"
         cmd: |
           set -o pipefail;
@@ -93,6 +95,7 @@
 
     - name: Search and replace owner of user's files.
       ansible.builtin.shell:
+        executable: /bin/bash
         cmd: "find / -mount -uid {{ item.0 }} -exec chown {{ item.1 }} '{}' +"
       loop: "{{ os_setup_user_mapping }}"
       changed_when: true
@@ -119,6 +122,7 @@
 
     - name: Search and replace group of group's files.
       ansible.builtin.shell:
+        executable: /bin/bash
         cmd: "find / -mount -gid {{ item.0 }} -exec chgrp {{ item.1 }} '{}' +"
       loop: "{{ os_setup_group_mapping }}"
       changed_when: true


### PR DESCRIPTION
Set `executable: /bin/bash` for all `ansible.builtin.shell` tasks for predictability.

Only affects tasks in `remap_user.yml`, since this is the only file containing `ansible.builtin.shell` tasks.

Solves this problem (relatd to https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1057).

```
TASK [usegalaxy_eu.handy.os_setup : Compute user mapping using script.] ********************************************************************************************************************
fatal: [maintenance.galaxyproject.eu -> localhost]: FAILED! => {"changed": false, "cmd": "set -o pipefail;\n./remap_user.py \\\n     -e 0:root -e 1:bin -e 2:daemon -e 3:adm -e 4:lp -e 5:sync -e 6:shutdown -e 7:halt -e 8:mail -e 11:operator -e 12:games -e 14:ftp -e 65534:nobody -e 81:dbus -e 500:systemd-coredump -e 193:systemd-resolve -e 59:tss -e 998:polkitd -e 997:unbound -e 996:sssd -e 74:sshd -e 72:tcpdump -e 995:pesign -e 32:rpc -e 29:rpcuser -e 994:telegraf -e 993:chrony -e 1000:centos -e 999:galaxy -e 499:gluster -e 989:dnsmasq -e 498:saslauth -e 497:condor -e 107:qemu \\\n     -d 999:galaxy \\\n    | tail -n +2\n", "delta": "0:00:00.004574", "end": "2023-12-20 09:08:07.362578", "msg": "non-zero return code", "rc": 2, "start": "2023-12-20 09:08:07.358004", "stderr": "/bin/sh: 1: set: Illegal option -o pipefail", "stderr_lines": ["/bin/sh: 1: set: Illegal option -o pipefail"], "stdout": "", "stdout_lines": []}
```