### PR TITLE
Bump collection version number to 3.1.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: usegalaxy_eu
 name: handy
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.1.0
+version: 3.1.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
The only changes since the last release are a bugfix https://github.com/usegalaxy-eu/ansible-collection-handy/pull/21. Therefore, I am increasing the patch version number.
