### PR TITLE
Allow triggering the Ansible Galaxy release workflow manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@
 name: Release
 
 'on':
+  workflow_dispatch:
   push:
     tags:
       - '*'


### PR DESCRIPTION
Add workflow_dispatch trigger to release.yml workflow so that the Ansible Galaxy uploads can be triggered manually.