### PR TITLE
Bump version from 3.2.0 to 3.3.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: usegalaxy_eu
 name: handy
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.0
+version: 3.3.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
A release was created, but the version was never bumped. I'll update the tag too once merged.